### PR TITLE
Version 1 trust details

### DIFF
--- a/app/assets/sass/_components.scss
+++ b/app/assets/sass/_components.scss
@@ -35,15 +35,6 @@
 }
 
 .dfe-side-nav {
-  .dfe-side-nav__heading {
-    font-weight: normal;
-    font-size: 1.1857rem;
-    color: $dfe-grey;
-    margin-bottom: 8px;
-    padding-top: 4px;
-    padding-left: 8px;
-    border-left: 4px solid transparent;
-  }
 
   .dfe-side-nav__list {
     @include govuk-responsive-margin(7, "bottom");
@@ -55,7 +46,7 @@
   .dfe-side-nav__item {
     padding-left: 8px;
     padding-bottom: 8px;
-    padding-top: 4px;
+    padding-top: 6px;
     box-sizing: content-box;
     border-left: 4px solid transparent;
   }
@@ -63,6 +54,19 @@
   .dfe-side-nav__item--current {
     background-color: $dfe-grey-light;
     border-color: $dfe-blue-secondary;
+    font-weight: bold;
+  }
+
+  .dfe-side-nav__heading {
+    @extend .dfe-side-nav__item;
+    font-weight: normal;
+    font-size: 1.1857rem;
+    color: $dfe-grey;
+    margin: 0;
+  }
+
+  .dfe-side-nav__link {
+    text-decoration: none;
   }
 }
 

--- a/app/assets/sass/_components.scss
+++ b/app/assets/sass/_components.scss
@@ -74,3 +74,16 @@
     border-color: $dfe-blue-secondary;
   }
 }
+
+.dfe-page-heading {
+  .dfe-page-heading__title {
+    @extend .govuk-heading-xl;
+    @include govuk-responsive-margin(3, "bottom");
+  }
+
+  .dfe-page-heading__detail {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: max-content max-content;
+  }
+}

--- a/app/assets/sass/_components.scss
+++ b/app/assets/sass/_components.scss
@@ -78,3 +78,15 @@
     grid-template-columns: max-content max-content;
   }
 }
+
+.dfe-data-source-list {
+  .dfe-data-source-list__item {
+    display: grid;
+    grid-template-columns: max-content max-content;
+    gap: 10px;
+  }
+
+  .dfe-data-source-list__title {
+    font-weight: bold;
+  }
+}

--- a/app/assets/sass/_components.scss
+++ b/app/assets/sass/_components.scss
@@ -1,4 +1,5 @@
 @import "node_modules/govuk-frontend/govuk/all";
+@import "./variables";
 
 .dfe-black-button {
   background-color: govuk-colour("black");
@@ -39,5 +40,37 @@
   .dfe-card-item {
     @include govuk-responsive-padding(5);
     background-color: govuk-colour("light-grey");
+  }
+}
+
+.dfe-side-nav {
+  .dfe-side-nav__heading {
+    font-weight: normal;
+    font-size: 1.1857rem;
+    color: $dfe-grey;
+    margin-bottom: 8px;
+    padding-top: 4px;
+    padding-left: 8px;
+    border-left: 4px solid transparent;
+  }
+
+  .dfe-side-nav__list {
+    @include govuk-responsive-margin(7, "bottom");
+    list-style-type: none;
+    padding: 0;
+    margin-top: 0;
+  }
+
+  .dfe-side-nav__item {
+    padding-left: 8px;
+    padding-bottom: 8px;
+    padding-top: 4px;
+    box-sizing: content-box;
+    border-left: 4px solid transparent;
+  }
+
+  .dfe-side-nav__item--current {
+    background-color: $dfe-grey-light;
+    border-color: $dfe-blue-secondary;
   }
 }

--- a/app/assets/sass/_components.scss
+++ b/app/assets/sass/_components.scss
@@ -29,18 +29,9 @@
   }
 }
 
-.dfe-card-grid {
-  display: grid;
-  grid-auto-flow: row;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 1.875rem;
-  list-style-type: none;
-  padding: 0;
-
-  .dfe-card-item {
-    @include govuk-responsive-padding(5);
-    background-color: govuk-colour("light-grey");
-  }
+.dfe-card {
+  @include govuk-responsive-padding(5);
+  background-color: govuk-colour("light-grey");
 }
 
 .dfe-side-nav {

--- a/app/assets/sass/_layout.scss
+++ b/app/assets/sass/_layout.scss
@@ -1,0 +1,7 @@
+.dfe-grid-3 {
+  display: grid;
+  grid-auto-flow: row;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1.875rem;
+  margin: 1em 0;
+}

--- a/app/assets/sass/_reset.scss
+++ b/app/assets/sass/_reset.scss
@@ -1,3 +1,4 @@
-dd {
+dl, dd {
   margin: 0;
+  padding: 0;
 }

--- a/app/assets/sass/_variables.scss
+++ b/app/assets/sass/_variables.scss
@@ -1,0 +1,5 @@
+$accent: #347ca9;
+$dfe-blue: #003a69;
+$dfe-blue-secondary: #1d70b8;
+$dfe-grey: #505a5f;
+$dfe-grey-light: #f4f2f2;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -5,13 +5,12 @@
 
 // Add extra styles here
 
+@import "./variables";
+
 @import "./components";
 @import "./reset";
 @import "./typography";
 @import "./utilities";
-
-$dfe-blue: #003a69;
-$accent: #347ca9;
 
 .dfe-template__body {
   .govuk-width-container {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -4,11 +4,11 @@
 // 
 
 // Add extra styles here
-
+@import "./reset";
 @import "./variables";
 
 @import "./components";
-@import "./reset";
+@import "./layout";
 @import "./typography";
 @import "./utilities";
 

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -49,18 +49,12 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
     {% endblock %}
   </div>
 </header>
-
-
-
-{% endblock %}
-
-{% block beforeContent %}
-
-{{ govukPhaseBanner({
-    tag: {
-      text: "alpha"
-    },
-    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-  }) }}
-
+<div class="govuk-width-container">
+  {{ govukPhaseBanner({
+      tag: {
+        text: "alpha"
+      },
+      html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+    }) }}
+  </div>
 {% endblock %}

--- a/app/views/layouts/trust.html
+++ b/app/views/layouts/trust.html
@@ -1,0 +1,62 @@
+{% extends "layouts/main.html" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-one-quarter">
+
+      <nav class="dfe-side-nav">
+
+        <h2 class="dfe-side-nav__heading">About the trust</h2>
+        <ul class="dfe-side-nav__list">
+          <li class="dfe-side-nav__item dfe-side-nav__item--current">
+            <a class="govuk-link govuk-link--no-visited-state" href="./trust-details">Trust details</a>
+          </li>
+          <li class="dfe-side-nav__item">
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Trust overview</a>
+          </li>
+          <li class="dfe-side-nav__item">
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Academies in this trust (17)</a>
+          </li>
+          <li class="dfe-side-nav__item">
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Governance</a>
+          </li>
+        </ul>
+
+        <h2 class="dfe-side-nav__heading">Risk and interventions</h2>
+        <ul class="dfe-side-nav__list">
+          <li class="dfe-side-nav__item">
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Cases and concerns</a>
+          </li>
+        </ul>
+
+        <h2 class="dfe-side-nav__heading">Educational performance</h2>
+        <ul class="dfe-side-nav__list">
+          <li class="dfe-side-nav__item">
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Primary</a>
+          </li>
+          <li class="dfe-side-nav__item">
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Secondary</a>
+          </li>
+        </ul>
+
+        <h2 class="dfe-side-nav__heading">Financial</h2>
+        <ul class="dfeuk-list dfe-side-nav__list">
+          <li class="dfe-side-nav__item">
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Financial data</a>
+          </li>
+          <li class="dfe-side-nav__item">
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Financial documents</a>
+          </li>
+        </ul>
+
+      </nav>
+
+    </div>
+
+    <div class="govuk-grid-column-three-quarters">
+      <h1>title</h1>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/layouts/trust.html
+++ b/app/views/layouts/trust.html
@@ -15,43 +15,43 @@ Abbey Lane Academies Trust – {{ serviceName }}
         <h2 class="dfe-side-nav__heading">About the trust</h2>
         <ul class="dfe-side-nav__list">
           <li class="dfe-side-nav__item dfe-side-nav__item--current">
-            <a class="govuk-link govuk-link--no-visited-state" href="./trust-details">Trust details</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="./trust-details">Trust details</a>
           </li>
           <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state" href="#">Trust overview</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Trust overview</a>
           </li>
           <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state" href="#">Academies in this trust (17)</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Academies in this trust (17)</a>
           </li>
           <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state" href="#">Governance</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Governance</a>
           </li>
         </ul>
 
         <h2 class="dfe-side-nav__heading">Risk and interventions</h2>
         <ul class="dfe-side-nav__list">
           <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state" href="#">Cases and concerns</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Cases and concerns</a>
           </li>
         </ul>
 
         <h2 class="dfe-side-nav__heading">Educational performance</h2>
         <ul class="dfe-side-nav__list">
           <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state" href="#">Primary</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Primary</a>
           </li>
           <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state" href="#">Secondary</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Secondary</a>
           </li>
         </ul>
 
         <h2 class="dfe-side-nav__heading">Financial</h2>
         <ul class="dfeuk-list dfe-side-nav__list">
           <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state" href="#">Financial data</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Financial data</a>
           </li>
           <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state" href="#">Financial documents</a>
+            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Financial documents</a>
           </li>
         </ul>
 

--- a/app/views/layouts/trust.html
+++ b/app/views/layouts/trust.html
@@ -55,8 +55,14 @@
 
     </div>
 
-    <div class="govuk-grid-column-three-quarters">
-      <h1>title</h1>
-    </div>
+    <main class="govuk-grid-column-three-quarters" id="main-content">
+      <header class="dfe-page-heading">
+        <h1 class="dfe-page-heading__title">Abbey Lane Academies Trust</h1>
+        <div class="dfe-page-heading__detail">
+          <p class="govuk-body"><span class="govuk-!-font-weight-bold">UID:</span> 1234</p>
+          <p class="govuk-body">Multi-academy trust</p>
+        </div>
+      </header>
+    </main>
   </div>
 {% endblock %}

--- a/app/views/layouts/trust.html
+++ b/app/views/layouts/trust.html
@@ -1,5 +1,9 @@
 {% extends "layouts/main.html" %}
 
+{% block pageTitle %}
+Abbey Lane Academies Trust – {{ serviceName }}
+{% endblock %}
+
 {% block content %}
 
   <div class="govuk-grid-row">
@@ -63,6 +67,7 @@
           <p class="govuk-body">Multi-academy trust</p>
         </div>
       </header>
+      {% block pageContent %}{% endblock %}
     </main>
   </div>
 {% endblock %}

--- a/app/views/layouts/trust.html
+++ b/app/views/layouts/trust.html
@@ -4,70 +4,75 @@
 Abbey Lane Academies Trust – {{ serviceName }}
 {% endblock %}
 
-{% block content %}
+{% block main %}
 
-  <div class="govuk-grid-row">
-
-    <div class="govuk-grid-column-one-quarter">
-
-      <nav class="dfe-side-nav">
-
-        <h2 class="dfe-side-nav__heading">About the trust</h2>
-        <ul class="dfe-side-nav__list">
-          <li class="dfe-side-nav__item dfe-side-nav__item--current">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="./trust-details">Trust details</a>
-          </li>
-          <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Trust overview</a>
-          </li>
-          <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Academies in this trust (17)</a>
-          </li>
-          <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Governance</a>
-          </li>
-        </ul>
-
-        <h2 class="dfe-side-nav__heading">Risk and interventions</h2>
-        <ul class="dfe-side-nav__list">
-          <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Cases and concerns</a>
-          </li>
-        </ul>
-
-        <h2 class="dfe-side-nav__heading">Educational performance</h2>
-        <ul class="dfe-side-nav__list">
-          <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Primary</a>
-          </li>
-          <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Secondary</a>
-          </li>
-        </ul>
-
-        <h2 class="dfe-side-nav__heading">Financial</h2>
-        <ul class="dfeuk-list dfe-side-nav__list">
-          <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Financial data</a>
-          </li>
-          <li class="dfe-side-nav__item">
-            <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Financial documents</a>
-          </li>
-        </ul>
-
-      </nav>
-
+<div class="govuk-main-wrapper ">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+  
+      <div class="govuk-grid-column-one-quarter">
+  
+        <nav class="dfe-side-nav">
+  
+          <h2 class="dfe-side-nav__heading">About the trust</h2>
+          <ul class="dfe-side-nav__list">
+            <li class="dfe-side-nav__item dfe-side-nav__item--current">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="./trust-details">Trust details</a>
+            </li>
+            <li class="dfe-side-nav__item">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Trust overview</a>
+            </li>
+            <li class="dfe-side-nav__item">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Academies in this trust (17)</a>
+            </li>
+            <li class="dfe-side-nav__item">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Governance</a>
+            </li>
+          </ul>
+  
+          <h2 class="dfe-side-nav__heading">Risk and interventions</h2>
+          <ul class="dfe-side-nav__list">
+            <li class="dfe-side-nav__item">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Cases and concerns</a>
+            </li>
+          </ul>
+  
+          <h2 class="dfe-side-nav__heading">Educational performance</h2>
+          <ul class="dfe-side-nav__list">
+            <li class="dfe-side-nav__item">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Primary</a>
+            </li>
+            <li class="dfe-side-nav__item">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Secondary</a>
+            </li>
+          </ul>
+  
+          <h2 class="dfe-side-nav__heading">Financial</h2>
+          <ul class="dfeuk-list dfe-side-nav__list">
+            <li class="dfe-side-nav__item">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Financial data</a>
+            </li>
+            <li class="dfe-side-nav__item">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Financial documents</a>
+            </li>
+          </ul>
+  
+        </nav>
+  
+      </div>
+  
+      <main class="govuk-grid-column-three-quarters" id="main-content">
+        <header class="dfe-page-heading">
+          <h1 class="dfe-page-heading__title">Abbey Lane Academies Trust</h1>
+          <div class="dfe-page-heading__detail">
+            <p class="govuk-body"><span class="govuk-!-font-weight-bold">UID:</span> 1234</p>
+            <p class="govuk-body">Multi-academy trust</p>
+          </div>
+        </header>
+        {% block pageContent %}{% endblock %}
+      </main>
     </div>
-
-    <main class="govuk-grid-column-three-quarters" id="main-content">
-      <header class="dfe-page-heading">
-        <h1 class="dfe-page-heading__title">Abbey Lane Academies Trust</h1>
-        <div class="dfe-page-heading__detail">
-          <p class="govuk-body"><span class="govuk-!-font-weight-bold">UID:</span> 1234</p>
-          <p class="govuk-body">Multi-academy trust</p>
-        </div>
-      </header>
-      {% block pageContent %}{% endblock %}
-    </main>
   </div>
+</div>
+
 {% endblock %}

--- a/app/views/version-1/home.html
+++ b/app/views/version-1/home.html
@@ -6,14 +6,6 @@ Find information about a Trust or Academy – {{ serviceName }}
 
 {% block main %}
 
-  <div class="govuk-grid-row govuk-width-container">
-    {{ govukPhaseBanner({
-      tag: {
-        text: "alpha"
-      },
-      html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-    }) }}
-  </div>
   <main id="main-content">
     <div class="dfe-callout">
       <div class="govuk-grid-row govuk-width-container">

--- a/app/views/version-1/home.html
+++ b/app/views/version-1/home.html
@@ -47,16 +47,16 @@ Find information about a Trust or Academy – {{ serviceName }}
         <div class="govuk-grid-column-full">
           <h2 class="govuk-heading-l">Related internal systems</h2>
           <p class="govuk-body">Use these services to find related information and other services provided by the Department for Education (DfE):</p>
-          <dl class="dfe-card-grid">
-            <div class="dfe-card-item">
+          <dl class="dfe-grid-3">
+            <div class="dfe-card">
               <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Data and reporting tool (DaRT)</a></dt>
               <dd class="govuk-body">Search to find and download information about schools, colleges, educational organisations and governors in England.</dd>
             </div>
-            <div class="dfe-card-item">
+            <div class="dfe-card">
               <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Knowledge Information Management (KIM)</a></dt>
               <dd class="govuk-body">Search to find and download information about schools, colleges, educational organisations and governors in England.</dd>
             </div>
-            <div class="dfe-card-item">
+            <div class="dfe-card">
               <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Regions Group data tool</a></dt>
               <dd class="govuk-body">Search to find and download information about schools, colleges, educational organisations and governors in England.</dd>
             </div>
@@ -67,24 +67,24 @@ Find information about a Trust or Academy – {{ serviceName }}
         <div class="govuk-grid-column-full">
           <h2 class="govuk-heading-l">Related public facing services</h2>
           <p class="govuk-body">Use these services to find related information and other services provided by the Department for Education (DfE):</p>
-          <dl class="dfe-card-grid">
-            <div class="dfe-card-item">
+          <dl class="dfe-grid-3">
+            <div class="dfe-card">
               <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Get information about schools</a></dt>
               <dd class="govuk-body">Search to find and download information about schools, colleges, educational organisations and governors in England.</dd>
             </div>
-            <div class="dfe-card-item">
+            <div class="dfe-card">
               <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Ofsted - Find an inspection report</a></dt>
               <dd class="govuk-body">You can find reports for schools, colleges, childminders, nurseries, children’s homes and more in England.</dd>
             </div>
-            <div class="dfe-card-item">
+            <div class="dfe-card">
               <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Statistics at DfE</a></dt>
               <dd class="govuk-body">Find out more about latest news, announcements, forthcoming releases and ad hoc publications, as well as related education statistics.</dd>
             </div>
-            <div class="dfe-card-item">
+            <div class="dfe-card">
               <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Schools financial benchmarking</a></dt>
               <dd class="govuk-body">Compare your school's income and expenditure with other schools in England.</dd>
             </div>
-            <div class="dfe-card-item">
+            <div class="dfe-card">
               <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Find and compare schools in England</a></dt>
               <dd class="govuk-body">Search for and check the performance of primary, secondary and special needs schools and colleges.</dd>
             </div>

--- a/app/views/version-1/home.html
+++ b/app/views/version-1/home.html
@@ -22,7 +22,7 @@ Find information about a Trust or Academy – {{ serviceName }}
           <p class="govuk-body">You can search for and download information on establishments, establishment groups (such as academies,
         trusts or federation).</p>
           <div >
-            <form class="govuk-form-group">
+            <form class="govuk-form-group" action="/version-1/trust-details" method="get">
               <div class="govuk-input__wrapper">
               <label class="dfeuk-u-visually-hidden" for="search">Search for a Trust or Academy by name, URN, location or local authority</label>
                 <input class="govuk-input dfe-search-input" id="search" placeholder="Search by name, URN, location or local authority">

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -23,7 +23,7 @@
         </dd>
       </dl>
     </div>
-    <section>
+    <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
       <h2>Trust details</h2>
 
       {{ govukSummaryList({
@@ -147,7 +147,7 @@
         '
       }) }}
     </section>
-    <section>
+    <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
       <h2>Trust details</h2>
 
       {{ govukSummaryList({
@@ -187,7 +187,7 @@
         ]
       }) }}
     </section>
-    <div>
+    <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
       <a class="govuk-link" href="#">Is there anything wrong with this page?</a>
     </div>
 

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -22,5 +22,130 @@
           <p class="govuk-!-margin-bottom-1">james.smith@education.gov.uk</p>
         </dd>
       </dl>
-  </div>
-{% endblock %}
+    </div>
+    <section>
+      <h2>Trust details</h2>
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Address:"
+            },
+            value: {
+              html: "Abbey Lane, Abbey Road, Sheffield, S1 2BC"
+            }
+          },
+          {
+            key: {
+              text: "Website:"
+            },
+            value: {
+              html: '<a class="govuk-link govuk-link--no-visited-state" href="http://www.abbeylanetrust.sch.uk">www.abbeylanetrust.sch.uk</a> (opens in a new tab)'
+            }
+          },
+          {
+            key: {
+              text: "Local authorites:"
+            },
+            value: {
+              html: '<a class="govuk-link govuk-link--no-visited-state" href="#">Sheffield</a> (88)'
+            }
+          },
+          {
+            key: {
+              text: "Regions Group:"
+            },
+            value: {
+              html: "South Yorkshire"
+            }
+          },
+          {
+            key: {
+              text: "National sponsor oversight:"
+            },
+            value: {
+              html: "---"
+            }
+          },
+          {
+            key: {
+              text: "Schools financial support territory (SFSO):"
+            },
+            value: {
+              html: "Yorkshire and the Humber"
+            }
+          },
+          {
+            key: {
+              text: "Date incorporated:"
+            },
+            value: {
+              html: "19 July 2010"
+            }
+          },
+          {
+            key: {
+              text: "Date opened:"
+            },
+            value: {
+              html: "1 Jan 2010"
+            }
+          },
+          {
+            key: {
+              text: "Trust reference number:"
+            },
+            value: {
+              html: "TR00123"
+            }
+          },
+          {
+            key: {
+              text: "Companies House number:"
+            },
+            value: {
+              html: "07318733"
+            }
+          },
+          {
+            key: {
+              text: "Companies House filing history:"
+            },
+            value: {
+              html: '<a class="govuk-link govuk-link--no-visited-state" href="https://find-and-update.company-information.service.gov.uk/company/07318714/filing-history">https://find-and-update.company-information.service.gov.uk/company/07318714/filing-history (opens in a new tab)</a>'
+            }
+          },
+          {
+            key: {
+              text: "Get information about schools:"
+            },
+            value: {
+              html: '<a class="govuk-link govuk-link--no-visited-state" href="#">View data held on Get information about schools (opens in a new tab)</a>'
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools<dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021<dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022<dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+
+  {% endblock %}

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -22,12 +22,13 @@
           <p class="govuk-!-margin-bottom-1"><a href="mailto:jen.hadfield@abbeylaneacademies.co.uk">jen.hadfield@abbeylaneacademies.co.uk</a></p>
           <p class="govuk-!-margin-bottom-1">Tel: 0114 201 3456</p>
         </dd>
-      </dl>
-    </div>
-    <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
-      <h2>Trust details</h2>
+      </div>
+    </dl>
+  </div>
+  <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <h2>Trust details</h2>
 
-      {{ govukSummaryList({
+    {{ govukSummaryList({
         rows: [
           {
             key: {
@@ -128,30 +129,30 @@
         ]
       }) }}
 
-      {{ govukDetails({
+    {{ govukDetails({
         summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
         html: '
           <dl class="dfe-data-source-list">
             <div class="dfe-data-source-list__item">
               <dt class="dfe-data-source-list__title">Data source:</dt>
-              <dd>Get information about schools<dd>
+              <dd>Get information about schools</dd>
             </div>
             <div class="dfe-data-source-list__item">
               <dt class="dfe-data-source-list__title">Last updated:</dt>
-              <dd>21 December 2021<dd>
+              <dd>21 December 2021</dd>
             </div>
             <div class="dfe-data-source-list__item">
               <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
-              <dd>21 January 2022<dd>
+              <dd>21 January 2022</dd>
             </div>
           </dl>
         '
       }) }}
-    </section>
-    <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
-      <h2>Sponsor details</h2>
+  </section>
+  <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <h2>Sponsor details</h2>
 
-      {{ govukSummaryList({
+    {{ govukSummaryList({
         rows: [
           {
             key: {
@@ -187,9 +188,9 @@
           }
         ]
       }) }}
-    </section>
-    <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
-      <a class="govuk-link" href="#">Is there anything wrong with this page?</a>
-    </div>
+  </section>
+  <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <a class="govuk-link" href="#">Is there anything wrong with this page?</a>
+  </div>
 
-  {% endblock %}
+{% endblock %}

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -7,19 +7,20 @@
         <dt class="govuk-heading-s govuk-!-margin-bottom-1">Trust relationship manager:</dt>
         <dd class="govuk-body govuk-!-margin-bottom-6">
           <p class="govuk-!-margin-bottom-1">James Smith</p>
-          <p class="govuk-!-margin-bottom-1">james.smith@education.gov.uk</p>
+          <p class="govuk-!-margin-bottom-1"><a class="govuk-link" href="mailto:james.smith@education.gov.uk">james.smith@education.gov.uk</a></p>
         </dd>
-        <dt class="govuk-heading-s govuk-!-margin-bottom-1">Trust relationship manager:</dt>
+        <dt class="govuk-heading-s govuk-!-margin-bottom-1">SFSO Lead:</dt>
         <dd class="govuk-body govuk-!-margin-bottom-0">
-          <p class="govuk-!-margin-bottom-1">James Smith</p>
-          <p class="govuk-!-margin-bottom-1">james.smith@education.gov.uk</p>
+          <p class="govuk-!-margin-bottom-1">Michelle Hadfield</p>
+          <p class="govuk-!-margin-bottom-1"><a class="govuk-link" href="mailto:michelle.hadfield@education.gov.uk">michelle.hadfield@education.gov.uk</a></p>
         </dd>
       </div>
       <div class="govuk-grid-column-one-half">
-        <dt class="govuk-heading-s govuk-!-margin-bottom-1">Trust relationship manager:</dt>
+        <dt class="govuk-heading-s govuk-!-margin-bottom-1">Main contact at trust:</dt>
         <dd class="govuk-body govuk-!-margin-bottom-6">
-          <p class="govuk-!-margin-bottom-1">James Smith</p>
-          <p class="govuk-!-margin-bottom-1">james.smith@education.gov.uk</p>
+          <p class="govuk-!-margin-bottom-1">Jen Hadfield - Chair of trustees</p>
+          <p class="govuk-!-margin-bottom-1"><a href="mailto:jen.hadfield@abbeylaneacademies.co.uk">jen.hadfield@abbeylaneacademies.co.uk</a></p>
+          <p class="govuk-!-margin-bottom-1">Tel: 0114 201 3456</p>
         </dd>
       </dl>
     </div>

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -193,3 +193,4 @@
     </div>
 
   {% endblock %}
+  

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -1,5 +1,1 @@
 {% extends "layouts/trust.html" %}
-
-{% block pageTitle %}
-My Trust – {{ serviceName }}
-{% endblock %}

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -1,1 +1,26 @@
 {% extends "layouts/trust.html" %}
+
+{% block pageContent %}
+  <div class="dfe-card">
+    <dl class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <dt class="govuk-heading-s govuk-!-margin-bottom-1">Trust relationship manager:</dt>
+        <dd class="govuk-body govuk-!-margin-bottom-6">
+          <p class="govuk-!-margin-bottom-1">James Smith</p>
+          <p class="govuk-!-margin-bottom-1">james.smith@education.gov.uk</p>
+        </dd>
+        <dt class="govuk-heading-s govuk-!-margin-bottom-1">Trust relationship manager:</dt>
+        <dd class="govuk-body govuk-!-margin-bottom-0">
+          <p class="govuk-!-margin-bottom-1">James Smith</p>
+          <p class="govuk-!-margin-bottom-1">james.smith@education.gov.uk</p>
+        </dd>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <dt class="govuk-heading-s govuk-!-margin-bottom-1">Trust relationship manager:</dt>
+        <dd class="govuk-body govuk-!-margin-bottom-6">
+          <p class="govuk-!-margin-bottom-1">James Smith</p>
+          <p class="govuk-!-margin-bottom-1">james.smith@education.gov.uk</p>
+        </dd>
+      </dl>
+  </div>
+{% endblock %}

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -147,5 +147,48 @@
         '
       }) }}
     </section>
+    <section>
+      <h2>Trust details</h2>
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Sponsor status:"
+            },
+            value: {
+              html: "Approved"
+            }
+          },
+          {
+            key: {
+              text: "Sponsor restrictions:"
+            },
+            value: {
+              html: "No restrictions"
+            }
+          },
+          {
+            key: {
+              text: "Sponsor approval date:"
+            },
+            value: {
+              html: "1 June 2010"
+            }
+          },
+          {
+            key: {
+              text: "Sponsor name:"
+            },
+            value: {
+              html: "Abbey Academies Trust"
+            }
+          }
+        ]
+      }) }}
+    </section>
+    <div>
+      <a class="govuk-link" href="#">Is there anything wrong with this page?</a>
+    </div>
 
   {% endblock %}

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -149,7 +149,7 @@
       }) }}
     </section>
     <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
-      <h2>Trust details</h2>
+      <h2>Sponsor details</h2>
 
       {{ govukSummaryList({
         rows: [
@@ -193,4 +193,3 @@
     </div>
 
   {% endblock %}
-  

--- a/app/views/version-1/trust-details.html
+++ b/app/views/version-1/trust-details.html
@@ -1,0 +1,5 @@
+{% extends "layouts/trust.html" %}
+
+{% block pageTitle %}
+My Trust – {{ serviceName }}
+{% endblock %}


### PR DESCRIPTION
- Create shared layout for trust pages with side nav
- Create Trust details page and content

Project wide
- Abstracted grid & card style for reusability (affects home html)
- Add a variables stylesheet to store colours

**Things to note**
The govuk main block variable includes a main element with id linked to 'skip to main content' link. When using the side nav layout we will need to override the main block to allow us to create a main element after the side nav, and to ensure the user does not need to tab through the side nav after skipping to main content.