### PR TITLE
Add Cases and concerns page

### DIFF
--- a/app/views/layouts/trust.html
+++ b/app/views/layouts/trust.html
@@ -32,8 +32,8 @@ Abbey Lane Academies Trust – {{ serviceName }}
   
           <h2 class="dfe-side-nav__heading">Risk and interventions</h2>
           <ul class="dfe-side-nav__list">
-            <li class="dfe-side-nav__item">
-              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Cases and concerns</a>
+            <li class="dfe-side-nav__item {% if current_page == 'cases-and-concerns' %}dfe-side-nav__item--current{% endif %}">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="./cases-and-concerns">Cases and concerns</a>
             </li>
           </ul>
   

--- a/app/views/version-1/cases-and-concerns.html
+++ b/app/views/version-1/cases-and-concerns.html
@@ -1,0 +1,391 @@
+{% extends "layouts/trust.html" %}
+{% set current_page = "cases-and-concerns" %}
+
+{% block pageContent %}
+  <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <h2 class="govuk-heading-l">Cases and concerns</h2>
+
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Open DaRT cases and concerns",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: "Lead contact"
+          },
+          {
+            text: "Description"
+          },
+          {
+            text: "Date last updated"
+          },
+          {
+            text: "Age (In months)",
+            format: "numeric"
+          }
+        ],
+        rows: [
+          [
+            {
+              html: '<a href="#">Governance and compliance</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Trust not displaying safeguarding policies on website"
+            },
+            {
+              text: "4 January 2023"
+            },
+            {
+              text: "1.6",
+              format: "numeric"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">Compliance</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "A longer description of a compliance concern that has been raised against the trust due to various reasons."
+            },
+            {
+              text: "14 November 2022"
+            },
+            {
+              text: "7.6",
+              format: "numeric"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">Governance and compliance</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "Governance concern"
+            },
+            {
+              text: "25 October 2021"
+            },
+            {
+              text: "12.2",
+              format: "numeric"
+            }
+          ]
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Open KIM cases and concerns",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: "Lead contact"
+          },
+          {
+            text: "Description"
+          },
+          {
+            text: "Date last updated"
+          },
+          {
+            text: "Age (In months)",
+            format: "numeric"
+          }
+        ],
+        rows: [
+          [
+            {
+              html: '<a href="#">Warning notice</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Warning notice"
+            },
+            {
+              text: "4 January 2023"
+            },
+            {
+              text: "12.6",
+              format: "numeric"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">Transfer</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Transfer"
+            },
+            {
+              text: "14 November 2022"
+            },
+            {
+              text: "7.6",
+              format: "numeric"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">Warning notice</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "Warning notice"
+            },
+            {
+              text: "25 October 2021"
+            },
+            {
+              text: "3.2",
+              format: "numeric"
+            }
+          ]
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Closed cases and concerns",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: "Lead contact"
+          },
+          {
+            text: "Type"
+          },
+          {
+            text: "Date closed"
+          }
+        ],
+        rows: [
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Concern"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Rachel Winter"
+            },
+            {
+              text: "Safeguarding"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "SRMA"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Concern"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Rachel Winter"
+            },
+            {
+              text: "SRMA"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "Safeguarding"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Safeguarding"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Rachel Winter"
+            },
+            {
+              text: "Safeguarding"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "Concern"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "SRMA"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ]
+         ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+  </div>
+{% endblock %}

--- a/app/views/version-1/cases-and-concerns.html
+++ b/app/views/version-1/cases-and-concerns.html
@@ -2,7 +2,7 @@
 {% set current_page = "cases-and-concerns" %}
 
 {% block pageContent %}
-  <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+  <div class="govuk-!-margin-top-7 govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-l">Cases and concerns</h2>
 
     <section class="govuk-!-margin-bottom-9">

--- a/app/views/version-1/financial-documents.html
+++ b/app/views/version-1/financial-documents.html
@@ -2,7 +2,7 @@
 {% set current_page = "financial-documents" %} 
 
 {% block pageContent %}
-  <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+  <section class="govuk-!-margin-top-7 govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-l govuk-!-margin-bottom-9">Financial Documents</h2>
 
     <div class="dfe-grid-2-column">

--- a/app/views/version-1/governance.html
+++ b/app/views/version-1/governance.html
@@ -2,7 +2,7 @@
 {% set current_page = "governance" %} 
 
 {% block pageContent %}
-  <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+  <div class="govuk-!-margin-top-7 govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-l">Governance</h2>
 
     {{ govukInsetText({


### PR DESCRIPTION
- Add Cases and Concerns page
- Adjusted vertical spacing between page title and academy details on Governance and Financial Docs pages to total 60px (they were slightly too big)