### PR TITLE
Add version 2

### DIFF
--- a/app/assets/sass/_components.scss
+++ b/app/assets/sass/_components.scss
@@ -158,3 +158,16 @@
     font-weight: bold;
   }
 }
+
+.dfe-summary-list-statistics--v2 {
+  .govuk-summary-list {
+    width: auto;
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list__key {
+    @include govuk-media-query($from: tablet) {
+      width: auto;
+    }
+  }
+}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -26,7 +26,29 @@ Versions – {{serviceName}} – GOV.UK Prototype Kit
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2><a href="/version-1/home" class="govuk-link govuk-link--no-visited-state">Version 1</a></h2>
+    <article>
+      <h2><a href="/version-2/home" class="govuk-link">Version 2</a></h2>
+      <p class="govuk-body">Iterations on the prototype kit to improve accessibility and usability across screen types:</p>
+      <ol class="govuk-list govuk-list--number">
+        <li>
+        <p>Develop style for statistics and figures.</p>
+        <p>In the first prototype some figures and statistics were laid out across two columns within grey cards. This layout changes significantly on smaller screens, and leads to unoptimal line lengths.</p></li>
+      </ol>
+      <hr class="govuk-section-break govuk-section-break--visible">
+    </article>
+    <article>
+      <h2><a href="/version-1/home" class="govuk-link">Version 1</a></h2>
+      <p class="govuk-body">Upgrade Figma prototype to use GOV.UK Prototype Kit to enable accessibility testing and user research. The following screens have been developed:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Home</li>
+        <li>Trust details</li>
+        <li>Academies in Trust</li>
+        <li>Governance</li>
+        <li>Cases and concerns</li>
+        <li>Financial documents</li>
+      </ul>
+      <hr class="govuk-section-break govuk-section-break--visible">
+    </article>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/version-2/academies-in-this-trust.html
+++ b/app/views/version-2/academies-in-this-trust.html
@@ -6,7 +6,7 @@
   <div class="dfe-card">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-6">Trust pupil numbers</h3>
 
-    <div class="dfe-summary-list-statistics">
+    <div class="dfe-summary-list-statistics--v2">
       {{ govukSummaryList({
         classes: 'govuk-summary-list--no-border',
         rows: [

--- a/app/views/version-2/academies-in-this-trust.html
+++ b/app/views/version-2/academies-in-this-trust.html
@@ -1,0 +1,827 @@
+{% extends "layouts/trust.html" %}
+{% set current_page = "academies-in-this-trust" %}
+
+{% block pageContent %}
+  <h2 class="govuk-heading-l govuk-!-margin-top-7">Academies in trust summary</h2>
+  <div class="dfe-card dfe-card--two-columns">
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-6">Trust pupil numbers</h3>
+    <dl class="dfe-summary-list-statistics dfe-card__content">
+      <div class="govuk-summary-list govuk-summary-list--no-border dfe-card__column">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Number of academies in trust</dt>
+          <dd class="govuk-summary-list__value govuk-body-l">17</dd>
+        </div>
+        <div  class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Trust actual pupil numbers</dt>
+          <dd class="govuk-summary-list__value govuk-body-l">15,856</dd>
+        </div>
+      </div>
+      <div class="govuk-summary-list govuk-summary-list--no-border dfe-card__column">
+        <div  class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Trust capacity</dt>
+          <dd class="govuk-summary-list__value govuk-body-l">16,256</dd>
+        </div>
+        <div  class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Trust capacity % full</dt>
+          <dd class="govuk-summary-list__value govuk-body-l">89%</dd>
+        </div>
+      </div>
+    </dl>
+  </div>
+{% endblock %}
+
+{% block pageContentColumnOverride %}
+
+  <div class="govuk-grid-column-full">
+
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6">
+
+    {{ govukTable({
+      attributes: {
+        'data-module': 'moj-sortable-table'
+      },
+      caption: "Academies in this trust (17)",
+      captionClasses: "govuk-table__caption--l",
+      head: [
+        {
+          text: "Establishment name",
+          attributes: {
+            "aria-sort": "ascending"
+          }
+        },
+        {
+          text: "Local authority",
+          attributes: {
+            "aria-sort": "none"
+          }
+        },
+        {
+          text: "Phase",
+          attributes: {
+            "aria-sort": "none"
+          }
+        },
+        {
+          text: "Age range",
+          attributes: {
+            "aria-sort": "none"
+          }
+        },
+        {
+            text: "Capacity",
+            attributes: {
+            "aria-sort": "none"
+            }
+        },
+        {
+            text: "Pupil numbers",
+            attributes: {
+            "aria-sort": "none"
+            }
+        },
+        {
+            text: "Date joined",
+            attributes: {
+            "aria-sort": "none"
+            }
+        },
+        {
+            text: "Current Ofsted rating",
+            attributes: {
+            "aria-sort": "none"
+            }
+        },
+        {
+            text: "Previous Ofsted rating",
+            attributes: {
+            "aria-sort": "none"
+            }
+        }
+      ],
+      rows: [
+        [
+          {
+            html: '<b>Abbey Grange Church of England Academy</b>',
+            attributes: {
+              "data-sort-value": "Abbey Grange Church of England Academy"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Secondary"
+          },
+          {
+            text: "11 - 18",
+            attributes: {
+              "data-sort-value": "1118"
+            }
+          },
+          {
+            text: "1,120",
+            attributes: {
+              "data-sort-value": "1120"
+            }
+          },
+          {
+            text: "1,607",
+            attributes: {
+              "data-sort-value": "1607"
+            }
+          },
+          {
+            text: "August 2011",
+            attributes: {
+              "data-sort-value": "20110801"
+            }
+          },
+          {
+            html: "<b>Good</b><br>9 Feb 2021"
+          },
+          {
+            html: "<b>Requires Improvement</b><br>7 May 2009"
+          }
+        ],
+        [
+          {
+            html: '<b>Bishop Young Church of England Academy</b>',
+            attributes: {
+              "data-sort-value": "Bishop Young Church of England Academy"
+            }
+          },
+          {
+            text: "Calderdale"
+          },
+          {
+            text: "Secondary"
+          },
+          {
+            text: "11 - 16",
+            attributes: {
+              "data-sort-value": "1116"
+            }
+          },
+          {
+            text: "900"
+          },
+          {
+            text: "683"
+
+          },
+          {
+            text: "May 2007",
+            attributes: {
+              "data-sort-value": "20070501"
+            }
+          },
+          {
+            html: "<b>Requires Improvement</b><br>22 Sept 2021"
+          },
+          {
+            html: "<b>Inadequate</b><br>30 Oct 2015"
+          }
+        ],
+        [
+          {
+            html: '<b>Christ Church Upper Armley Church of England Primary School</b>',
+            attributes: {
+              "data-sort-value": "Christ Church Upper Armley Church of England Primary School"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 11",
+            attributes: {
+              "data-sort-value": "411"
+            }
+          },
+          {
+            text: "230"
+          },
+          {
+            text: "173"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Oct 2017"
+          },
+          {
+            html: "<b>Good</b><br>13 Oct 2017"
+          }
+        ],
+        [
+          {
+            html: '<b>Holy Trinity Church of England Academy</b>',
+            attributes: {
+              "data-sort-value": "Holy Trinity Church of England Academy"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Secondary"
+          },
+          {
+            text: "11 - 18",
+            attributes: {
+              "data-sort-value": "1118"
+            }
+          },
+          {
+            text: "1,152",
+            attributes: {
+              "data-sort-value": "1152"
+            }
+          },
+          {
+            text: "1,607",
+            attributes: {
+              "data-sort-value": "1607"
+            }
+          },
+          {
+            text: "August 2011",
+            attributes: {
+              "data-sort-value": "20110801"
+            }
+          },
+          {
+            html: "<b>Good</b><br>9 Feb 2021"
+          },
+          {
+            html: "<b>Requires Improvement</b><br>7 May 2009"
+          }
+        ],
+        [
+          {
+            html: '<b>Chesterfield Academy</b>',
+            attributes: {
+              "data-sort-value": "Lightcliffe Academy"
+            }
+          },
+          {
+            text: "Calderdale"
+          },
+          {
+            text: "Secondary"
+          },
+          {
+            text: "11 - 16",
+            attributes: {
+              "data-sort-value": "1116"
+            }
+          },
+          {
+            text: "900"
+          },
+          {
+            text: "1008"
+
+          },
+          {
+            text: "May 2009",
+            attributes: {
+              "data-sort-value": "20090512"
+            }
+          },
+          {
+            html: "<b>Requires Improvement</b><br>22 Sept 2021"
+          },
+          {
+            html: "<b>Inadequate</b><br>30 Oct 2015"
+          }
+        ],
+        [
+          {
+            html: '<b>Darkcliffe C of E Primary School</b>',
+            attributes: {
+              "data-sort-value": "Darkcliffe C of E Primary School"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 11",
+            attributes: {
+              "data-sort-value": "411"
+            }
+          },
+          {
+            text: "190"
+          },
+          {
+            text: "173"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Oct 2017"
+          },
+          {
+            html: "<b>Good</b><br>13 Oct 2017"
+          }
+        ],
+        [
+          {
+            html: '<b>St Chad’s Church of England Primary School</b>',
+            attributes: {
+              "data-sort-value": "St Chad’s Church of England Primary School"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 9",
+            attributes: {
+              "data-sort-value": "49"
+            }
+          },
+          {
+            text: "1,152",
+            attributes: {
+              "data-sort-value": "1152"
+            }
+          },
+          {
+            text: "1,607",
+            attributes: {
+              "data-sort-value": "1607"
+            }
+          },
+          {
+            text: "August 2011",
+            attributes: {
+              "data-sort-value": "20110801"
+            }
+          },
+          {
+            html: "<b>Good</b><br>9 Feb 2021"
+          },
+          {
+            html: "<b>Requires Improvement</b><br>7 May 2009"
+          }
+        ],
+        [
+          {
+            html: '<b>Lightcliffe Academy</b>',
+            attributes: {
+              "data-sort-value": "Lightcliffe Academy"
+            }
+          },
+          {
+            text: "Calderdale"
+          },
+          {
+            text: "Secondary"
+          },
+          {
+            text: "11 - 16",
+            attributes: {
+              "data-sort-value": "1116"
+            }
+          },
+          {
+            text: "900"
+          },
+          {
+            text: "683"
+
+          },
+          {
+            text: "May 2007",
+            attributes: {
+              "data-sort-value": "20070501"
+            }
+          },
+          {
+            html: "<b>Requires Improvement</b><br>22 Sept 2021"
+          },
+          {
+            html: "<b>Inadequate</b><br>30 Oct 2015"
+          }
+        ],
+        [
+          {
+            html: '<b>Lightcliffe C of E Primary School</b>',
+            attributes: {
+              "data-sort-value": "Lightcliffe C of E Primary School"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 11",
+            attributes: {
+              "data-sort-value": "411"
+            }
+          },
+          {
+            text: "195"
+          },
+          {
+            text: "173"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Oct 2017"
+          },
+          {
+            html: "<b>Good</b><br>13 Oct 2017"
+          }
+        ],
+        [
+          {
+            html: "<b>St Cuthbert's Church of England Primary School</b>",
+            attributes: {
+              "data-sort-value": "St Cuthbert's Church of England Primary School"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 11",
+            attributes: {
+              "data-sort-value": "411"
+            }
+          },
+          {
+            text: "1,152",
+            attributes: {
+              "data-sort-value": "1152"
+            }
+          },
+          {
+            text: "1,607",
+            attributes: {
+              "data-sort-value": "1607"
+            }
+          },
+          {
+            text: "August 2011",
+            attributes: {
+              "data-sort-value": "20110801"
+            }
+          },
+          {
+            html: "<b>Good</b><br>9 Feb 2021"
+          },
+          {
+            html: "<b>Requires Improvement</b><br>7 May 2009"
+          }
+        ],
+        [
+          {
+            html: '<b>Holy Trinity Church of England Academy</b>',
+            attributes: {
+              "data-sort-value": "Holy Trinity Church of England Academy"
+            }
+          },
+          {
+            text: "Calderdale"
+          },
+          {
+            text: "Secondary"
+          },
+          {
+            text: "11 - 16",
+            attributes: {
+              "data-sort-value": "1116"
+            }
+          },
+          {
+            text: "900"
+          },
+          {
+            text: "683"
+
+          },
+          {
+            text: "May 2007",
+            attributes: {
+              "data-sort-value": "20070501"
+            }
+          },
+          {
+            html: "<b>Requires Improvement</b><br>22 Sept 2021"
+          },
+          {
+            html: "<b>Inadequate</b><br>30 Oct 2015"
+          }
+        ],
+        [
+          {
+            html: '<b>Westcliffe C of E Primary School</b>',
+            attributes: {
+              "data-sort-value": "Westcliffe C of E Primary School"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 11",
+            attributes: {
+              "data-sort-value": "411"
+            }
+          },
+          {
+            text: "800"
+          },
+          {
+            text: "768"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Oct 2017"
+          },
+          {
+            html: "<b>Good</b><br>13 Oct 2017"
+          }
+        ],
+        [
+          {
+            html: '<b>Orchard Primary School</b>',
+            attributes: {
+              "data-sort-value": "Orchard Primary School"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 11",
+            attributes: {
+              "data-sort-value": "411"
+            }
+          },
+          {
+            text: "210"
+          },
+          {
+            text: "173"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Oct 2017"
+          },
+          {
+            html: "<b>Good</b><br>13 Oct 2017"
+          }
+        ],
+        [
+          {
+            html: '<b>Leeds Girls Academy</b>',
+            attributes: {
+              "data-sort-value": "Leeds Girls Academy"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Secondary"
+          },
+          {
+            text: "11 - 18",
+            attributes: {
+              "data-sort-value": "1118"
+            }
+          },
+          {
+            text: "210"
+          },
+          {
+            text: "173"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Oct 2017"
+          },
+          {
+            html: "<b>Good</b><br>13 Oct 2017"
+          }
+        ],
+        [
+          {
+            html: '<b>Northbourne CofE Primary School</b>',
+            attributes: {
+              "data-sort-value": "Northbourne CofE Primary School"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 11",
+            attributes: {
+              "data-sort-value": "411"
+            }
+          },
+          {
+            text: "230"
+          },
+          {
+            text: "179"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Oct 2017"
+          },
+          {
+            html: "<b>Good</b><br>13 Oct 2017"
+          }
+        ],
+        [
+          {
+            html: '<b>Our Ladys Convent Academy</b>',
+            attributes: {
+              "data-sort-value": "Our Ladys Convent Academy"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Primary"
+          },
+          {
+            text: "4 - 11",
+            attributes: {
+              "data-sort-value": "411"
+            }
+          },
+          {
+            text: "210"
+          },
+          {
+            text: "173"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Oct 2017"
+          },
+          {
+            html: "<b>Good</b><br>13 Oct 2017"
+          }
+        ],
+        [
+          {
+            html: '<b>Mossbourne Community Academy</b>',
+            attributes: {
+              "data-sort-value": "Mossbourne Community Academy"
+            }
+          },
+          {
+            text: "Leeds"
+          },
+          {
+            text: "Secondary"
+          },
+          {
+            text: "11 - 18",
+            attributes: {
+              "data-sort-value": "1118"
+            }
+          },
+          {
+            text: "205"
+          },
+          {
+            text: "173"
+
+          },
+          {
+            text: "Sep 2018",
+            attributes: {
+              "data-sort-value": "20180901"
+            }
+          },
+          {
+            html: "<b>Inadequate</b><br>13 Jan 2018"
+          },
+          {
+            html: "<b>Good</b><br>10 Oct 2017"
+          }
+        ]
+              
+      ]
+    }) }}
+
+    <div class="dfe-flex-between">
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+
+      <button class="dfe-image-button">
+        <svg class="dfe-image-button__image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <path d="M23,4H22V21a1,1,0,0,1-1,1H4v1a1,1,0,0,0,1,1H23a1,1,0,0,0,1-1V5A1,1,0,0,0,23,4Z"/>
+          <path d="M19,20a1,1,0,0,0,1-1V1a1,1,0,0,0-1-1H1A1,1,0,0,0,0,1V19a1,1,0,0,0,1,1H19Z"/>
+        </svg>
+        Download data
+      </button>
+    </div>
+
+    <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-4">
+      <a class="govuk-body govuk-link  govuk-link--no-visited-state" href="#" class="govuk-link govuk-link--no-visited-state">Is there anything wrong with this page?</a>
+    </div>
+  </div>
+
+{% endblock %}
+
+{# Override anything wrong link block because it is manually included above #}
+{% block anythingWrong %}{% endblock %}

--- a/app/views/version-2/academies-in-this-trust.html
+++ b/app/views/version-2/academies-in-this-trust.html
@@ -3,30 +3,48 @@
 
 {% block pageContent %}
   <h2 class="govuk-heading-l govuk-!-margin-top-7">Academies in trust summary</h2>
-  <div class="dfe-card dfe-card--two-columns">
+  <div class="dfe-card">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-6">Trust pupil numbers</h3>
-    <dl class="dfe-summary-list-statistics dfe-card__content">
-      <div class="govuk-summary-list govuk-summary-list--no-border dfe-card__column">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Number of academies in trust</dt>
-          <dd class="govuk-summary-list__value govuk-body-l">17</dd>
-        </div>
-        <div  class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Trust actual pupil numbers</dt>
-          <dd class="govuk-summary-list__value govuk-body-l">15,856</dd>
-        </div>
-      </div>
-      <div class="govuk-summary-list govuk-summary-list--no-border dfe-card__column">
-        <div  class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Trust capacity</dt>
-          <dd class="govuk-summary-list__value govuk-body-l">16,256</dd>
-        </div>
-        <div  class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Trust capacity % full</dt>
-          <dd class="govuk-summary-list__value govuk-body-l">89%</dd>
-        </div>
-      </div>
-    </dl>
+
+    <div class="dfe-summary-list-statistics">
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: {
+              text: "Number of academies in trust"
+            },
+            value: {
+              text: "17"
+            }
+          },
+          {
+            key: {
+              text: "Trust actual pupil numbers"
+            },
+            value: {
+              text: "15,856"
+            }
+          },
+          {
+            key: {
+              text: "Trust capacity"
+            },
+            value: {
+              text: "16,256"
+            }
+          },
+          {
+            key: {
+              text: "Trust capacity % full"
+            },
+            value: {
+              text: "89%"
+            }
+          }
+        ]
+      }) }}
+    </div>
   </div>
 {% endblock %}
 
@@ -34,7 +52,7 @@
 
   <div class="govuk-grid-column-full">
 
-    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6">
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-6">
 
     {{ govukTable({
       attributes: {

--- a/app/views/version-2/cases-and-concerns.html
+++ b/app/views/version-2/cases-and-concerns.html
@@ -1,0 +1,391 @@
+{% extends "layouts/trust.html" %}
+{% set current_page = "cases-and-concerns" %}
+
+{% block pageContent %}
+  <div class="govuk-!-margin-top-7 govuk-!-margin-bottom-8">
+    <h2 class="govuk-heading-l">Cases and concerns</h2>
+
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Open DaRT cases and concerns",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: "Lead contact"
+          },
+          {
+            text: "Description"
+          },
+          {
+            text: "Date last updated"
+          },
+          {
+            text: "Age (In months)",
+            format: "numeric"
+          }
+        ],
+        rows: [
+          [
+            {
+              html: '<a href="#">Governance and compliance</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Trust not displaying safeguarding policies on website"
+            },
+            {
+              text: "4 January 2023"
+            },
+            {
+              text: "1.6",
+              format: "numeric"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">Compliance</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "A longer description of a compliance concern that has been raised against the trust due to various reasons."
+            },
+            {
+              text: "14 November 2022"
+            },
+            {
+              text: "7.6",
+              format: "numeric"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">Governance and compliance</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "Governance concern"
+            },
+            {
+              text: "25 October 2021"
+            },
+            {
+              text: "12.2",
+              format: "numeric"
+            }
+          ]
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Open KIM cases and concerns",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: "Lead contact"
+          },
+          {
+            text: "Description"
+          },
+          {
+            text: "Date last updated"
+          },
+          {
+            text: "Age (In months)",
+            format: "numeric"
+          }
+        ],
+        rows: [
+          [
+            {
+              html: '<a href="#">Warning notice</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Warning notice"
+            },
+            {
+              text: "4 January 2023"
+            },
+            {
+              text: "12.6",
+              format: "numeric"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">Transfer</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Transfer"
+            },
+            {
+              text: "14 November 2022"
+            },
+            {
+              text: "7.6",
+              format: "numeric"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">Warning notice</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "Warning notice"
+            },
+            {
+              text: "25 October 2021"
+            },
+            {
+              text: "3.2",
+              format: "numeric"
+            }
+          ]
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Closed cases and concerns",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: "Lead contact"
+          },
+          {
+            text: "Type"
+          },
+          {
+            text: "Date closed"
+          }
+        ],
+        rows: [
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Concern"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Rachel Winter"
+            },
+            {
+              text: "Safeguarding"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "SRMA"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Concern"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Rachel Winter"
+            },
+            {
+              text: "SRMA"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "Safeguarding"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Safeguarding"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Rachel Winter"
+            },
+            {
+              text: "Safeguarding"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "James Cheetham"
+            },
+            {
+              text: "Concern"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              html: '<a href="#">ESFA Concern</a>'
+            },
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "SRMA"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ]
+         ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+  </div>
+{% endblock %}

--- a/app/views/version-2/financial-documents.html
+++ b/app/views/version-2/financial-documents.html
@@ -1,0 +1,154 @@
+{% extends "layouts/trust.html" %}
+{% set current_page = "financial-documents" %} 
+
+{% block pageContent %}
+  <section class="govuk-!-margin-top-7 govuk-!-margin-bottom-8">
+    <h2 class="govuk-heading-l govuk-!-margin-bottom-9">Financial Documents</h2>
+
+    <div class="dfe-grid-2-column">
+      <h2 class="govuk-heading-m">Financial statements</h2>
+      <dl class="govuk-summary-list dfe-summary-list-narrow govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2021/22</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2021/22</span> statements (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2020/21</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2020/21</span> statements (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2019/20</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2019/20</span> statements (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2018/19</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2018/19</span> statements (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+      </dl>
+      <h2 class="govuk-heading-m">Management letters</h2>
+      <dl class="govuk-summary-list dfe-summary-list-narrow govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2021/22</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2021/22</span> letters (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2020/21</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2020/21</span> letters (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2019/20</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2019/20</span> letters (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2018/19</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2018/19</span> letters (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+      </dl>
+    </div>
+    <div class="dfe-grid-2-column">
+      <h2 class="govuk-heading-m">School resource management self assessment tool checklist</h2>
+      <dl class="govuk-summary-list dfe-summary-list-narrow govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2021/22</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2021/22</span> checklist (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2020/21</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2020/21</span> checklist (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2019/20</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2019/20</span> checklist (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2018/19</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2018/19</span> checklist (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+      </dl>
+      <h2 class="govuk-heading-m">Internal audit reports</h2>
+      <dl class="govuk-summary-list dfe-summary-list-narrow govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2021/22</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2021/22</span> reports (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2020/21</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2020/21</span> reports (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2019/20</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2019/20</span> reports (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">2018/19</dt>
+          <dd class="govuk-summary-list__value">
+            <a class="govuk-link" href="#">
+              View <span class="govuk-visually-hidden">2018/19</span> reports (opens in a new tab)
+            </a>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </section>
+  
+{% endblock %}

--- a/app/views/version-2/governance.html
+++ b/app/views/version-2/governance.html
@@ -1,0 +1,383 @@
+{% extends "layouts/trust.html" %}
+{% set current_page = "governance" %} 
+
+{% block pageContent %}
+  <div class="govuk-!-margin-top-7 govuk-!-margin-bottom-8">
+    <h2 class="govuk-heading-l">Governance</h2>
+
+    {{ govukInsetText({
+      html: '<a class="govuk-link" href="#">View this trust on Companies House officer information (opens in new tab)</a>'
+    }) }}
+
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Present",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Full name"
+          },
+          {
+            text: "Trust role"
+          },
+          {
+            text: "Date appointed"
+          }
+        ],
+        rows: [
+          [
+            {
+              html: 'Mark Abbey<br><a href="mailto:mark.abbey@abbeylanetrust.org.uk">mark.abbey@abbeylanetrust.org.uk</a>'
+            },
+            {
+              text: "Accounting Officer"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              html: 'Jen Hadfield<br><a href="mailto:jen.hadfield@abbeylane.trust.org.uk">jen.hadfield@abbeylane.trust.org.uk</a>'
+            },
+            {
+              text: "Chair of Trustees"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              text: "Colin Coles"
+            },
+            {
+              text: "Chief Financial Officer"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              text: "Cheryl Ann Hobbs"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              text: "Nicholas Martin"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              text: "Keith Evans"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              text: "Rachael Cave"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              text: "Lee Mccall"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              text: "George Harper"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              text: "Phil Pearson"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ]
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Members",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Full name"
+          },
+          {
+            text: "Trust role"
+          },
+          {
+            text: "Date appointed"
+          }
+        ],
+        rows: [
+          [
+            {
+              text: "David Kilshaw"
+            },
+            {
+              text: "Member"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              text: "Beverley Laws"
+            },
+            {
+              text: "Member"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              text: "Lee Headland"
+            },
+            {
+              text: "Member"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ]
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+    <section class="govuk-!-margin-bottom-9">
+      {{ govukTable({
+        caption: "Previous",
+        captionClasses: "govuk-table__caption--m",
+        head: [
+          {
+            text: "Full name"
+          },
+          {
+            text: "Trust role"
+          },
+          {
+            text: "Date appointed"
+          }
+        ],
+        rows: [
+          [
+            {
+              text: "Mark Abbey"
+            },
+            {
+              text: "Accounting Officer"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              text: "Jen Hadfield"
+            },
+            {
+              text: "Chair of Trustees"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              text: "Colin Coles"
+            },
+            {
+              text: "Chief Financial Officer"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              text: "Cheryl Ann Hobbs"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              text: "Nicholas Martin"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              text: "Keith Evans"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              text: "Rachael Cave"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ],
+          [
+            {
+              text: "Lee Mccall"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "14 November 2022"
+            }
+          ],
+          [
+            {
+              text: "George Harper"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "25 October 2021"
+            }
+          ],
+          [
+            {
+              text: "Phil Pearson"
+            },
+            {
+              text: "Trustee"
+            },
+            {
+              text: "4 January 2023"
+            }
+          ]
+        ]
+      }) }}
+
+      {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+    </section>
+  </div>
+{% endblock %}

--- a/app/views/version-2/home.html
+++ b/app/views/version-2/home.html
@@ -1,0 +1,98 @@
+{% extends "layouts/main.html" %}
+{% set current_page = "home" %} 
+
+{% block pageTitle %}
+  Find information about a Trust or Academy – {{ serviceName }}
+{% endblock %}
+
+{% block main %}
+
+  <main id="main-content">
+    <div class="dfe-callout">
+      <div class="govuk-grid-row govuk-width-container">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-xl">Find information about a Trust or Academy</h1>
+            <form class="govuk-form-group" action="/version-2/trust-details" method="get">
+              <label class="govuk-body" for="search">
+                Search for a Trust or Academy by name, URN, location or local authority
+              </label>
+              <div class="govuk-input__wrapper govuk-!-margin-top-4">
+                <input class="govuk-input dfe-search-input" id="search">
+                <button class="govuk-button dfe-black-button dfe-inline-button" data-module="govuk-button" type="submit">
+                  <span class="govuk-visually-hidden">Search</span>
+                  <svg width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                    <circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3"></circle>
+                    <line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3"></line>
+                  </svg>
+                </button>
+              </div>
+            </form>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <p class="govuk-body"><a href="#" class="govuk-link govuk-link--inverse">Contact the TRAMS team</a> with any comments or questions</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-width-container">
+      <section class="govuk-grid-row govuk-!-margin-top-9">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-l">Related internal systems</h2>
+          <p class="govuk-body">Use these services to find related information and other services provided by the Department for Education (DfE):</p>
+          <dl class="dfe-grid-3">
+            <div class="dfe-card">
+              <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Data and reporting tool (DaRT)</a></dt>
+              <dd class="govuk-body">Search to find and download information about schools, colleges, educational organisations and governors in England.</dd>
+            </div>
+            <div class="dfe-card">
+              <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Knowledge Information Management (KIM)</a></dt>
+              <dd class="govuk-body">Search to find and download information about schools, colleges, educational organisations and governors in England.</dd>
+            </div>
+            <div class="dfe-card">
+              <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Regions Group data tool</a></dt>
+              <dd class="govuk-body">Search to find and download information about schools, colleges, educational organisations and governors in England.</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+      <section class="govuk-grid-row  govuk-!-margin-top-7 govuk-!-margin-bottom-6">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-l">Related public facing services</h2>
+          <p class="govuk-body">Use these services to find related information and other services provided by the Department for Education (DfE):</p>
+          <dl class="dfe-grid-3">
+            <div class="dfe-card">
+              <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Get information about schools</a></dt>
+              <dd class="govuk-body">Search to find and download information about schools, colleges, educational organisations and governors in England.</dd>
+            </div>
+            <div class="dfe-card">
+              <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Ofsted - Find an inspection report</a></dt>
+              <dd class="govuk-body">You can find reports for schools, colleges, childminders, nurseries, children’s homes and more in England.</dd>
+            </div>
+            <div class="dfe-card">
+              <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Statistics at DfE</a></dt>
+              <dd class="govuk-body">Find out more about latest news, announcements, forthcoming releases and ad hoc publications, as well as related education statistics.</dd>
+            </div>
+            <div class="dfe-card">
+              <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Schools financial benchmarking</a></dt>
+              <dd class="govuk-body">Compare your school's income and expenditure with other schools in England.</dd>
+            </div>
+            <div class="dfe-card">
+              <dt class="dfe-heading-lite-m"><a href="#" class="govuk-link govuk-link--no-visited-state">Find and compare schools in England</a></dt>
+              <dd class="govuk-body">Search for and check the performance of primary, secondary and special needs schools and colleges.</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+      <hr class="govuk-section-break govuk-section-break--visible">
+      <section class="govuk-grid-row govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-l">Contact us</h2>
+          <p class="govuk-body">The Trust and Academy Management Information Service is operated by the Department for Education (DfE).</p>
+          <p class="govuk-body">If you need help and support or have a question please contact:</p>
+          <h3 class="govuk-heading-s">Trust and Academy Management Information</h3>
+          <p class="govuk-body">Email <a href="mailto:TRAMS@education.gov.uk">TRAMS@education.gov.uk</a></p>
+        </div>
+      </section>
+    </div>
+  </main>
+{% endblock %}

--- a/app/views/version-2/trust-details.html
+++ b/app/views/version-2/trust-details.html
@@ -1,0 +1,194 @@
+{% extends "layouts/trust.html" %}
+{% set current_page = "trust-details" %} 
+
+{% block pageContent %}
+  <div class="dfe-card  dfe-card--two-columns">
+    <dl class="dfe-card__content">
+      <div class="dfe-card__column">
+        <dt class="govuk-heading-s govuk-!-margin-bottom-1">Trust relationship manager:</dt>
+        <dd class="govuk-body govuk-!-margin-bottom-6">
+          <p class="govuk-!-margin-bottom-1">James Smith</p>
+          <p class="govuk-!-margin-bottom-1"><a class="govuk-link" href="mailto:james.smith@education.gov.uk">james.smith@education.gov.uk</a></p>
+        </dd>
+        <dt class="govuk-heading-s govuk-!-margin-bottom-1">SFSO Lead:</dt>
+        <dd class="govuk-body govuk-!-margin-bottom-6">
+          <p class="govuk-!-margin-bottom-1">Michelle Hadfield</p>
+          <p class="govuk-!-margin-bottom-1"><a class="govuk-link" href="mailto:michelle.hadfield@education.gov.uk">michelle.hadfield@education.gov.uk</a></p>
+        </dd>
+      </div>
+      <div class="dfe-card__column">
+        <dt class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Main contact at trust:</dt>
+        <dd class="govuk-body govuk-!-margin-bottom-6">
+          <p class="govuk-!-margin-bottom-1">Jen Hadfield - Chair of trustees</p>
+          <p class="govuk-!-margin-bottom-1"><a href="mailto:jen.hadfield@abbeylaneacademies.co.uk">jen.hadfield@abbeylaneacademies.co.uk</a></p>
+          <p class="govuk-!-margin-bottom-1">Tel: 0114 201 3456</p>
+        </dd>
+      </div>
+    </dl>
+  </div>
+  <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <h2>Trust details</h2>
+
+    {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Address:"
+            },
+            value: {
+              html: "Abbey Lane, Abbey Road, Sheffield, S1 2BC"
+            }
+          },
+          {
+            key: {
+              text: "Website:"
+            },
+            value: {
+              html: '<a class="govuk-link govuk-link--no-visited-state" href="http://www.abbeylanetrust.sch.uk">www.abbeylanetrust.sch.uk</a> (opens in a new tab)'
+            }
+          },
+          {
+            key: {
+              text: "Local authorites:"
+            },
+            value: {
+              html: '<a class="govuk-link govuk-link--no-visited-state" href="#">Sheffield</a> (88)'
+            }
+          },
+          {
+            key: {
+              text: "Regions Group:"
+            },
+            value: {
+              html: "South Yorkshire"
+            }
+          },
+          {
+            key: {
+              text: "National sponsor oversight:"
+            },
+            value: {
+              html: "---"
+            }
+          },
+          {
+            key: {
+              text: "Schools financial support territory (SFSO):"
+            },
+            value: {
+              html: "Yorkshire and the Humber"
+            }
+          },
+          {
+            key: {
+              text: "Date incorporated:"
+            },
+            value: {
+              html: "19 July 2010"
+            }
+          },
+          {
+            key: {
+              text: "Date opened:"
+            },
+            value: {
+              html: "1 Jan 2010"
+            }
+          },
+          {
+            key: {
+              text: "Trust reference number:"
+            },
+            value: {
+              html: "TR00123"
+            }
+          },
+          {
+            key: {
+              text: "Companies House number:"
+            },
+            value: {
+              html: "07318733"
+            }
+          },
+          {
+            key: {
+              text: "Companies House filing history:"
+            },
+            value: {
+              html: '<a class="govuk-link govuk-link--no-visited-state" href="https://find-and-update.company-information.service.gov.uk/company/07318714/filing-history">https://find-and-update.company-information.service.gov.uk/company/07318714/filing-history (opens in a new tab)</a>'
+            }
+          },
+          {
+            key: {
+              text: "Get information about schools:"
+            },
+            value: {
+              html: '<a class="govuk-link govuk-link--no-visited-state" href="#">View data held on Get information about schools (opens in a new tab)</a>'
+            }
+          }
+        ]
+      }) }}
+
+    {{ govukDetails({
+        summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+        html: '
+          <dl class="dfe-data-source-list">
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Data source:</dt>
+              <dd>Get information about schools</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Last updated:</dt>
+              <dd>21 December 2021</dd>
+            </div>
+            <div class="dfe-data-source-list__item">
+              <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+              <dd>21 January 2022</dd>
+            </div>
+          </dl>
+        '
+      }) }}
+  </section>
+  <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <h2>Sponsor details</h2>
+
+    {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Sponsor status:"
+            },
+            value: {
+              html: "Approved"
+            }
+          },
+          {
+            key: {
+              text: "Sponsor restrictions:"
+            },
+            value: {
+              html: "No restrictions"
+            }
+          },
+          {
+            key: {
+              text: "Sponsor approval date:"
+            },
+            value: {
+              html: "1 June 2010"
+            }
+          },
+          {
+            key: {
+              text: "Sponsor name:"
+            },
+            value: {
+              html: "Abbey Academies Trust"
+            }
+          }
+        ]
+      }) }}
+  </section>
+
+{% endblock %}


### PR DESCRIPTION
This pull request introduces the first iterations of version 2 of the prototype, which diverge from designs prototyped in Figma. 

Version 2 will contain all screens currently developed, as we are iterating on designs on the current screens. 

1. Create version 2 prototype, add descriptions to log differences
2. Reduce differences from GOV.UK Summary list on pupil numbers statistics on 'Academies in Trusts Page' - Statistics will be in one column, as in a standard summary list component.