### PR TITLE
Add trust overview page and update contact details layout

### DIFF
--- a/app/assets/sass/version-2/_components.scss
+++ b/app/assets/sass/version-2/_components.scss
@@ -71,11 +71,6 @@
       }
     }
 
-    &--align-vertically {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-    }
   }
 
   .dfe-side-nav {
@@ -145,7 +140,7 @@
   }
 
   .dfe-summary-list-statistics {
-    .govuk-summary-list {
+    &.gov-uk-summary-list, .govuk-summary-list {
       width: auto;
       margin-bottom: 0;
     }

--- a/app/assets/sass/version-2/_components.scss
+++ b/app/assets/sass/version-2/_components.scss
@@ -70,6 +70,12 @@
         flex: 1 1 45%;
       }
     }
+
+    &--align-vertically {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
   }
 
   .dfe-side-nav {

--- a/app/assets/sass/version-2/_layout.scss
+++ b/app/assets/sass/version-2/_layout.scss
@@ -96,7 +96,7 @@
     gap: 1.875rem;
     margin: 1em 0;
 
-    @include govuk-media-query($until: tablet) {
+    @include govuk-media-query($until: desktop) {
       display: block;
 
       .dfe-grid-2__item {

--- a/app/assets/sass/version-2/_layout.scss
+++ b/app/assets/sass/version-2/_layout.scss
@@ -89,6 +89,22 @@
     }
   }
 
+  .dfe-grid-2 {
+    display: grid;
+    grid-auto-flow: row;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.875rem;
+    margin: 1em 0;
+
+    @include govuk-media-query($until: tablet) {
+      display: block;
+
+      .dfe-grid-2__item {
+        margin-bottom: 1.875rem;
+      }
+    }
+  }
+
   .dfe-grid-2-column {
     display: grid;
     grid-auto-flow: column;

--- a/app/assets/sass/version-2/_typography.scss
+++ b/app/assets/sass/version-2/_typography.scss
@@ -5,4 +5,10 @@
     @extend .govuk-heading-m;
     font-weight: normal;
   }
+
+  .dfe-statistic-large {
+    font-size: 5rem;
+    line-height: 5.25rem;
+    font-weight: bold;
+  }
 }

--- a/app/views/version-2/includes/contact.html
+++ b/app/views/version-2/includes/contact.html
@@ -1,5 +1,4 @@
 {% macro contact(type, showTelephone = false) %}
-  <dd class="govuk-body govuk-!-margin-bottom-6">
     <p class="govuk-!-margin-bottom-1">{{ type['name'] }}</p>
     <p class="govuk-!-margin-bottom-1">
       <a class="govuk-link" href="{{ type['email'] }}">{{ type['email'] }}</a>
@@ -7,5 +6,4 @@
     {% if showTelephone and type['telephone'] %}
       <p class="govuk-!-margin-bottom-1">Tel: {{ type['telephone'] }}</p>
     {% endif %}
-  </dd>
 {% endmacro %}

--- a/app/views/version-2/includes/contact.html
+++ b/app/views/version-2/includes/contact.html
@@ -1,9 +1,9 @@
 {% macro contact(type, showTelephone = false) %}
-    <p class="govuk-!-margin-bottom-1">{{ type['name'] }}</p>
-    <p class="govuk-!-margin-bottom-1">
-      <a class="govuk-link" href="{{ type['email'] }}">{{ type['email'] }}</a>
-    </p>
-    {% if showTelephone and type['telephone'] %}
-      <p class="govuk-!-margin-bottom-1">Tel: {{ type['telephone'] }}</p>
-    {% endif %}
+  <p class="govuk-!-margin-bottom-1">{{ type['name'] }}</p>
+  <p class="govuk-!-margin-bottom-1">
+    <a class="govuk-link" href="{{ type['email'] }}">{{ type['email'] }}</a>
+  </p>
+  {% if showTelephone and type['telephone'] %}
+    <p class="govuk-!-margin-bottom-1">Tel: {{ type['telephone'] }}</p>
+  {% endif %}
 {% endmacro %}

--- a/app/views/version-2/includes/data-source.html
+++ b/app/views/version-2/includes/data-source.html
@@ -2,18 +2,18 @@
   summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
   classes: 'govuk-!-margin-bottom-0',
   html: '
-    <dl class="dfe-data-source-list">
-      <div class="dfe-data-source-list__item">
-        <dt class="dfe-data-source-list__title">Data source:</dt>
-        <dd>Get information about schools</dd>
+    <dl class="govuk-summary-list govuk-summary-list--no-border dfe-summary-list-statistics">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Data source</dt>
+        <dd class="govuk-summary-list__value">Get information about schools</dd>
       </div>
-      <div class="dfe-data-source-list__item">
-        <dt class="dfe-data-source-list__title">Last updated:</dt>
-        <dd>21 December 2021</dd>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Last updated</dt>
+        <dd class="govuk-summary-list__value">21 December 2021</dd>
       </div>
-      <div class="dfe-data-source-list__item">
-        <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
-        <dd>21 January 2022</dd>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Next scheduled update</dt>
+        <dd class="govuk-summary-list__value">21 January 2022</dd>
       </div>
     </dl>
   '

--- a/app/views/version-2/includes/data-source.html
+++ b/app/views/version-2/includes/data-source.html
@@ -1,0 +1,20 @@
+{{ govukDetails({
+  summaryHtml: '<span>Data source</span> <span>(last updated 21 December 2021)</span>',
+  classes: 'govuk-!-margin-bottom-0',
+  html: '
+    <dl class="dfe-data-source-list">
+      <div class="dfe-data-source-list__item">
+        <dt class="dfe-data-source-list__title">Data source:</dt>
+        <dd>Get information about schools</dd>
+      </div>
+      <div class="dfe-data-source-list__item">
+        <dt class="dfe-data-source-list__title">Last updated:</dt>
+        <dd>21 December 2021</dd>
+      </div>
+      <div class="dfe-data-source-list__item">
+        <dt class="dfe-data-source-list__title">Next scheduled update:</dt>
+        <dd>21 January 2022</dd>
+      </div>
+    </dl>
+  '
+}) }}

--- a/app/views/version-2/includes/internal-data-use.html
+++ b/app/views/version-2/includes/internal-data-use.html
@@ -1,0 +1,4 @@
+{{ govukWarningText({
+  text: "This data is for internal use only",
+  iconFallbackText: "Warning"
+}) }}

--- a/app/views/version-2/layouts/trust.html
+++ b/app/views/version-2/layouts/trust.html
@@ -19,8 +19,8 @@
             <li class="dfe-side-nav__item {% if current_page == 'trust-details' %}dfe-side-nav__item--current{% endif %}">
               <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="./trust-details">Trust details</a>
             </li>
-            <li class="dfe-side-nav__item">
-              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="#">Trust overview</a>
+            <li class="dfe-side-nav__item {% if current_page == 'trust-overview' %}dfe-side-nav__item--current{% endif %}">
+              <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="./trust-overview">Trust overview</a>
             </li>
             <li class="dfe-side-nav__item {% if current_page == 'academies-in-this-trust' %}dfe-side-nav__item--current{% endif %}">
               <a class="govuk-link govuk-link--no-visited-state dfe-side-nav__link" href="./academies-in-this-trust">Academies in this trust (17)</a>

--- a/app/views/version-2/trust-details.html
+++ b/app/views/version-2/trust-details.html
@@ -1,24 +1,51 @@
 {% extends "./layouts/trust.html" %}
 {% from "./includes/contact.html" import contact %}
 {% from "./includes/link.njk" import link %}
-{% set current_page = "trust-details" %} 
+{% set current_page = "trust-details" %}
 
 {% block pageContent %}
-  <div class="dfe-card  dfe-card--two-columns">
-    <dl class="dfe-card__content">
-      <div class="dfe-card__column">
-        <dt class="govuk-heading-s govuk-!-margin-bottom-1">Trust relationship manager:</dt>
-        {{ contact(data.trust.trustDetails.trustRelationshipManager) }}
-        <dt class="govuk-heading-s govuk-!-margin-bottom-1">SFSO Lead:</dt>
-        {{ contact(data.trust.trustDetails.sfsoLead) }}
-      </div>
-      <div class="dfe-card__column">
-        <dt class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Main contact at trust:</dt>
-        {{ contact(data.trust.trustDetails.mainContactAtTrust, true) }}
-      </div>
-    </dl>
-  </div>
-  <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+  <section class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
+    <h2>Internal DfE contacts</h2>
+
+    {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Trust relationship manager"
+            },
+            value: {
+              html: contact(data.trust.trustDetails.trustRelationshipManager)
+            }
+          },
+          {
+            key: {
+              text: "SFSO Lead"
+            },
+            value: {
+              html: contact(data.trust.trustDetails.sfsoLead)
+            }
+          }
+        ]
+      }) }}
+  </section>
+  <section class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
+    <h2>External Trust contacts</h2>
+
+    {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Chair of Trustees"
+            },
+            value: {
+              html: contact(data.trust.trustDetails.mainContactAtTrust, showTelephone=true)
+            }
+          }
+        ]
+      }) }}
+  </section>
+
+  <section class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
     <h2>Trust details</h2>
 
     {{ govukSummaryList({
@@ -146,7 +173,7 @@
         '
       }) }}
   </section>
-  <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+  <section class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
     <h2>Sponsor details</h2>
 
     {{ govukSummaryList({

--- a/app/views/version-2/trust-overview.html
+++ b/app/views/version-2/trust-overview.html
@@ -1,0 +1,182 @@
+{% extends "./layouts/trust.html" %}
+{% set current_page = "trust-overview" %}
+
+{% block pageContent %}
+  <section class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
+    <div class="dfe-grid-2">
+      <div class="dfe-card dfe-grid-2__item">
+        {{ govukTable({
+          attributes: {
+            'data-module': 'moj-sortable-table'
+          },
+          caption: "Ofsted data",
+          captionClasses: "govuk-table__caption--m",
+          head: [
+            {
+              text: "Rating",
+              attributes: {
+                "aria-sort": "ascending"
+              }
+            },
+            {
+              text: "Number of schools",
+              attributes: {
+                "aria-sort": "none"
+              },
+              format: "numeric"
+            }
+          ],
+          rows: [
+            [
+              {
+                text: 'Outstanding',
+                attributes: {
+                  "data-sort-value": "1"
+                }
+              },
+              {
+                text: "3",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: 'Good',
+                attributes: {
+                  "data-sort-value": "2"
+                }
+              },
+              {
+                text: "5",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: 'Requires improvement',
+                attributes: {
+                  "data-sort-value": "3"
+                }
+              },
+              {
+                text: "2",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: 'Inadequate',
+                attributes: {
+                  "data-sort-value": "4"
+                }
+              },
+              {
+                text: "3",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: 'Not yet inspected',
+                attributes: {
+                  "data-sort-value": "5"
+                }
+              },
+              {
+                text: "4",
+                format: "numeric"
+              }
+            ]
+          ]
+        }) }}
+      </div>
+      <div class="dfe-card dfe-grid-2__item">
+        {{ govukTable({
+          attributes: {
+            'data-module': 'moj-sortable-table'
+          },
+          caption: "Free school meals data",
+          captionClasses: "govuk-table__caption--m",
+          head: [
+            {
+              text: "Rating",
+              attributes: {
+                "aria-sort": "ascending"
+              }
+            },
+            {
+              text: "Number of schools",
+              attributes: {
+                "aria-sort": "none"
+              },
+              format: "numeric"
+            }
+          ],
+          rows: [
+            [
+              {
+                text: 'Outstanding',
+                attributes: {
+                  "data-sort-value": "1"
+                }
+              },
+              {
+                text: "3",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: 'Good',
+                attributes: {
+                  "data-sort-value": "2"
+                }
+              },
+              {
+                text: "5",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: 'Requires improvement',
+                attributes: {
+                  "data-sort-value": "3"
+                }
+              },
+              {
+                text: "2",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: 'Inadequate',
+                attributes: {
+                  "data-sort-value": "4"
+                }
+              },
+              {
+                text: "3",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: 'Not yet inspected',
+                attributes: {
+                  "data-sort-value": "5"
+                }
+              },
+              {
+                text: "4",
+                format: "numeric"
+              }
+            ]
+          ]
+        }) }}
+      </div>
+    </div>
+  </section>
+
+{% endblock %}

--- a/app/views/version-2/trust-overview.html
+++ b/app/views/version-2/trust-overview.html
@@ -5,8 +5,7 @@
   <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
     <div class="dfe-grid-2">
       
-      <article class="dfe-card dfe-card--align-vertically dfe-grid-2__item">
-        <div>
+      <article class="dfe-card dfe-grid-2__item">
           {% include "./includes/internal-data-use.html"%}
           <h2 class="govuk-heading-m">Trust risk grade</h2>
           <div>
@@ -14,56 +13,53 @@
             <p class="govuk-body">Expected to be stable in the short-term, but potentially exposed to adverse events in the long-term</p>
             <p class="govuk-body"><a class="govuk-link" href="#">School Financial Benchmarking data (Opens in a new tab)</a></p>
           </div>
-        </div>  
         {% include "./includes/data-source.html"%}
       </article>
 
-      <article class="dfe-card dfe-card--align-vertically dfe-grid-2__item">
+      <article class="dfe-card dfe-grid-2__item">
         {# TODO: This card needs a title or label #}
-        <div>
-          {% include "./includes/internal-data-use.html"%}
-          {{ govukSummaryList({
-            classes: 'govuk-summary-list--no-border dfe-summary-list-statistics govuk-!-margin-bottom-0',
-            rows: [
-              {
-                key: {
-                  text: "Latest trust banding score"
-                },
-                value: {
-                  html: "Upper Consolidate"
-                }
+        {% include "./includes/internal-data-use.html"%}
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border dfe-summary-list-statistics',
+          rows: [
+            {
+              key: {
+                text: "Latest trust banding score"
               },
-              {
-                key: {
-                  text: "Date of trust review meeting"
-                },
-                value: {
-                  text: "1 Feb 2023"
-                }
-              },
-              {
-                key: {
-                  text: "Single joint risk rating"
-                },
-                value: {
-                  text: "Monitor"
-                }
-              },
-              {
-                key: {
-                  text: "SFSO concern level"
-                },
-                value: {
-                  text: "Amber / Green"
-                }
+              value: {
+                html: "Upper Consolidate"
               }
-            ]
-          }) }}
-        </div>
+            },
+            {
+              key: {
+                text: "Date of trust review meeting"
+              },
+              value: {
+                text: "1 Feb 2023"
+              }
+            },
+            {
+              key: {
+                text: "Single joint risk rating"
+              },
+              value: {
+                text: "Monitor"
+              }
+            },
+            {
+              key: {
+                text: "SFSO concern level"
+              },
+              value: {
+                text: "Amber / Green"
+              }
+            }
+          ]
+        }) }}
         {% include "./includes/data-source.html"%}
       </article>
 
-      <article class="dfe-card dfe-card--align-vertically dfe-grid-2__item">
+      <article class="dfe-card dfe-grid-2__item">
         {{ govukTable({
           attributes: {
             'data-module': 'moj-sortable-table'
@@ -151,7 +147,7 @@
         }) }}
         {% include "./includes/data-source.html"%}
       </article>
-      <article class="dfe-card dfe-card--align-vertically dfe-grid-2__item">
+      <article class="dfe-card dfe-grid-2__item">
         {{ govukTable({
           attributes: {
             'data-module': 'moj-sortable-table'

--- a/app/views/version-2/trust-overview.html
+++ b/app/views/version-2/trust-overview.html
@@ -2,9 +2,9 @@
 {% set current_page = "trust-overview" %}
 
 {% block pageContent %}
-  <section class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
+  <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
     <div class="dfe-grid-2">
-      <div class="dfe-card dfe-grid-2__item">
+      <article class="dfe-card dfe-grid-2__item">
         {{ govukTable({
           attributes: {
             'data-module': 'moj-sortable-table'
@@ -89,8 +89,8 @@
             ]
           ]
         }) }}
-      </div>
-      <div class="dfe-card dfe-grid-2__item">
+      </article>
+      <article class="dfe-card dfe-grid-2__item">
         {{ govukTable({
           attributes: {
             'data-module': 'moj-sortable-table'
@@ -175,8 +175,8 @@
             ]
           ]
         }) }}
-      </div>
+      </article>
     </div>
-  </section>
+  </div>
 
 {% endblock %}

--- a/app/views/version-2/trust-overview.html
+++ b/app/views/version-2/trust-overview.html
@@ -82,6 +82,7 @@
               attributes: {
                 "aria-sort": "none"
               },
+              classes: 'govuk-!-width-one-third',
               format: "numeric"
             }
           ],
@@ -169,6 +170,7 @@
               attributes: {
                 "aria-sort": "none"
               },
+              classes: 'govuk-!-width-one-third',
               format: "numeric"
             }
           ],

--- a/app/views/version-2/trust-overview.html
+++ b/app/views/version-2/trust-overview.html
@@ -5,59 +5,65 @@
   <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
     <div class="dfe-grid-2">
       
-      <article class="dfe-card dfe-grid-2__item">
-        {% include "./includes/internal-data-use.html"%}
-        <h2 class="govuk-heading-m">Trust risk grade</h2>
+      <article class="dfe-card dfe-card--align-vertically dfe-grid-2__item">
         <div>
-          <p class="dfe-statistic-large">C</p>
-          <p class="govuk-body">Expected to be stable in the short-term, but potentially exposed to adverse events in the long-term</p>
-          <p class="govuk-body"><a class="govuk-link" href="#">School Financial Benchmarking data (Opens in a new tab)</a></p>
-        </div>
+          {% include "./includes/internal-data-use.html"%}
+          <h2 class="govuk-heading-m">Trust risk grade</h2>
+          <div>
+            <p class="dfe-statistic-large">C</p>
+            <p class="govuk-body">Expected to be stable in the short-term, but potentially exposed to adverse events in the long-term</p>
+            <p class="govuk-body"><a class="govuk-link" href="#">School Financial Benchmarking data (Opens in a new tab)</a></p>
+          </div>
+        </div>  
+        {% include "./includes/data-source.html"%}
       </article>
 
-      <article class="dfe-card dfe-grid-2__item">
+      <article class="dfe-card dfe-card--align-vertically dfe-grid-2__item">
         {# TODO: This card needs a title or label #}
-        {% include "./includes/internal-data-use.html"%}
-        {{ govukSummaryList({
-          classes: 'govuk-summary-list--no-border dfe-summary-list-statistics govuk-!-margin-bottom-0',
-          rows: [
-            {
-              key: {
-                text: "Latest trust banding score"
+        <div>
+          {% include "./includes/internal-data-use.html"%}
+          {{ govukSummaryList({
+            classes: 'govuk-summary-list--no-border dfe-summary-list-statistics govuk-!-margin-bottom-0',
+            rows: [
+              {
+                key: {
+                  text: "Latest trust banding score"
+                },
+                value: {
+                  html: "Upper Consolidate"
+                }
               },
-              value: {
-                html: "Upper Consolidate"
-              }
-            },
-            {
-              key: {
-                text: "Date of trust review meeting"
+              {
+                key: {
+                  text: "Date of trust review meeting"
+                },
+                value: {
+                  text: "1 Feb 2023"
+                }
               },
-              value: {
-                text: "1 Feb 2023"
-              }
-            },
-            {
-              key: {
-                text: "Single joint risk rating"
+              {
+                key: {
+                  text: "Single joint risk rating"
+                },
+                value: {
+                  text: "Monitor"
+                }
               },
-              value: {
-                text: "Monitor"
+              {
+                key: {
+                  text: "SFSO concern level"
+                },
+                value: {
+                  text: "Amber / Green"
+                }
               }
-            },
-            {
-              key: {
-                text: "SFSO concern level"
-              },
-              value: {
-                text: "Amber / Green"
-              }
-            }
-          ]
-        }) }}
+            ]
+          }) }}
+        </div>
+        {% include "./includes/data-source.html"%}
       </article>
 
-      <article class="dfe-card dfe-grid-2__item">
+      <article class="dfe-card dfe-card--align-vertically dfe-grid-2__item">
         {{ govukTable({
           attributes: {
             'data-module': 'moj-sortable-table'
@@ -142,8 +148,9 @@
             ]
           ]
         }) }}
+        {% include "./includes/data-source.html"%}
       </article>
-      <article class="dfe-card dfe-grid-2__item">
+      <article class="dfe-card dfe-card--align-vertically dfe-grid-2__item">
         {{ govukTable({
           attributes: {
             'data-module': 'moj-sortable-table'
@@ -228,6 +235,7 @@
             ]
           ]
         }) }}
+        {% include "./includes/data-source.html"%}
       </article>
     </div>
   </div>

--- a/app/views/version-2/trust-overview.html
+++ b/app/views/version-2/trust-overview.html
@@ -95,11 +95,11 @@
           attributes: {
             'data-module': 'moj-sortable-table'
           },
-          caption: "Free school meals data",
+          caption: "Free school meals %",
           captionClasses: "govuk-table__caption--m",
           head: [
             {
-              text: "Rating",
+              text: "% banding",
               attributes: {
                 "aria-sort": "ascending"
               }
@@ -115,33 +115,9 @@
           rows: [
             [
               {
-                text: 'Outstanding',
+                text: "0 - 10%",
                 attributes: {
                   "data-sort-value": "1"
-                }
-              },
-              {
-                text: "3",
-                format: "numeric"
-              }
-            ],
-            [
-              {
-                text: 'Good',
-                attributes: {
-                  "data-sort-value": "2"
-                }
-              },
-              {
-                text: "5",
-                format: "numeric"
-              }
-            ],
-            [
-              {
-                text: 'Requires improvement',
-                attributes: {
-                  "data-sort-value": "3"
                 }
               },
               {
@@ -151,9 +127,21 @@
             ],
             [
               {
-                text: 'Inadequate',
+                text: "10 - 30%",
                 attributes: {
-                  "data-sort-value": "4"
+                  "data-sort-value": "2"
+                }
+              },
+              {
+                text: "2",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: "30 - 50%",
+                attributes: {
+                  "data-sort-value": "3"
                 }
               },
               {
@@ -163,13 +151,25 @@
             ],
             [
               {
-                text: 'Not yet inspected',
+                text: "50 - 70%",
+                attributes: {
+                  "data-sort-value": "4"
+                }
+              },
+              {
+                text: "7",
+                format: "numeric"
+              }
+            ],
+            [
+              {
+                text: "70 - 100%",
                 attributes: {
                   "data-sort-value": "5"
                 }
               },
               {
-                text: "4",
+                text: "3",
                 format: "numeric"
               }
             ]

--- a/app/views/version-2/trust-overview.html
+++ b/app/views/version-2/trust-overview.html
@@ -4,6 +4,59 @@
 {% block pageContent %}
   <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
     <div class="dfe-grid-2">
+      
+      <article class="dfe-card dfe-grid-2__item">
+        {% include "./includes/internal-data-use.html"%}
+        <h2 class="govuk-heading-m">Trust risk grade</h2>
+        <div>
+          <p class="dfe-statistic-large">C</p>
+          <p class="govuk-body">Expected to be stable in the short-term, but potentially exposed to adverse events in the long-term</p>
+          <p class="govuk-body"><a class="govuk-link" href="#">School Financial Benchmarking data (Opens in a new tab)</a></p>
+        </div>
+      </article>
+
+      <article class="dfe-card dfe-grid-2__item">
+        {# TODO: This card needs a title or label #}
+        {% include "./includes/internal-data-use.html"%}
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border dfe-summary-list-statistics govuk-!-margin-bottom-0',
+          rows: [
+            {
+              key: {
+                text: "Latest trust banding score"
+              },
+              value: {
+                html: "Upper Consolidate"
+              }
+            },
+            {
+              key: {
+                text: "Date of trust review meeting"
+              },
+              value: {
+                text: "1 Feb 2023"
+              }
+            },
+            {
+              key: {
+                text: "Single joint risk rating"
+              },
+              value: {
+                text: "Monitor"
+              }
+            },
+            {
+              key: {
+                text: "SFSO concern level"
+              },
+              value: {
+                text: "Amber / Green"
+              }
+            }
+          ]
+        }) }}
+      </article>
+
       <article class="dfe-card dfe-grid-2__item">
         {{ govukTable({
           attributes: {


### PR DESCRIPTION
- Add trust overview page, with sample trust overview data in table and text format
- Update contacts to use GOV.UK Summary List component and clearly define internal and external contacts

Things to note: external contact details have changed so have shown 'Main contact at trust' as the 'Chair of Trustees' at the moment, we may want to reformat the response data here to make it less role specific. 