### PR TITLE
Re-add image button css for download data button

### DIFF
--- a/app/assets/sass/version-3/_components.scss
+++ b/app/assets/sass/version-3/_components.scss
@@ -32,6 +32,26 @@
 
   }
 
+  .dfe-image-button {
+    @extend .govuk-button;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    background: none;
+    box-shadow: none;
+    border: transparent;
+    color: $govuk-link-colour;
+
+    &:hover {
+      background-color: $govuk-link-colour;
+    }
+
+    .dfe-image-button__image {
+      height: 20px;
+      fill: currentColor;
+    }
+  }
+
   .dfe-search-button {
     margin-left: 10px;
   }
@@ -124,7 +144,6 @@
 
     .dfe-page-heading__detail {
       @include grid-2-row-variable-width(1.25rem);
-     
     }
   }
 


### PR DESCRIPTION
Re-add css class that was accidentally removed from version three. This styles the download data button on the Academies in Trust page