### PR TITLE
Add css reset for list items

### DIFF
--- a/app/assets/sass/_reset.scss
+++ b/app/assets/sass/_reset.scss
@@ -1,4 +1,8 @@
-dl, dd {
+dl, dd, li {
   margin: 0;
   padding: 0;
+}
+
+ul > li {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
DfE frontend has set some styles for html elements (e.g. lists), which are affecting the appearance of the MOJ sub nav. Added a reset to our application styles which remove these.